### PR TITLE
Clarify that published pack files are aarch64 (but 'work' on x86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ bash ./link.sh --and-run clang --version
 ### x86-64
 Requirements: `elfshaker`, `wget`, `git`, `docker`
 
+Please note, that so far, moment packs are only published for aarch64 binaries.
+However, these binaries can run under qemu with some performance impact. For
+small code fragments, or some use cases, the impact may be tolerable.
+
 Replace `YYYYMM` below with the month and year for which you wish to fetch builds.
 ```bash
 mkdir -p manyclangs/elfshaker_data/packs manyclangs/bin


### PR DESCRIPTION
Clang binaries from the pack files will run on x86, with some performance penalty. Just wanted to note that.