### PR TITLE
Make python available in the docker container

### DIFF
--- a/docker-qemu-aarch64/Dockerfile
+++ b/docker-qemu-aarch64/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
         libtinfo6:arm64=6.* \
         libzstd1:arm64=1.* \
         qemu-user \
+        python3 \
     && ln -s /usr/lib/aarch64-linux-gnu/libtinfo.so.6 /usr/lib/aarch64-linux-gnu/libtinfo.so \
     && ln -s /usr/lib/aarch64-linux-gnu/libzstd.so.1 /usr/lib/aarch64-linux-gnu/libzstd.so \
     && apt-get clean \


### PR DESCRIPTION
Clangd crashes can't always be triggered by a command line invocation of clangd, sometimes they need clangd to be driven by an LSP client which sends it messages on its stdin.

Reporters of clangd bugs often provide reproducers in the form of python scripts, so it's convenient to be able to run such scripts inside the container.